### PR TITLE
[fix] API 중복 요청 방지 - mutation.isPending 가드 추가 (#78)

### DIFF
--- a/app/(tabs)/air/report.tsx
+++ b/app/(tabs)/air/report.tsx
@@ -52,7 +52,7 @@ export default function Report() {
   // 평균 비행 속도
   const averageSpeed = flightDistance / seconds;
 
-  const { mutate } = usePostFlightLog({
+  const { mutate, isPending } = usePostFlightLog({
     memberId: memberId as string,
     onSuccess: async (response) => {
       if (!response) return;
@@ -65,6 +65,7 @@ export default function Report() {
   });
 
   const onPressSave = () => {
+    if (isPending) return;
     mutate({
       airfieldName,
       flightTime,
@@ -111,7 +112,7 @@ export default function Report() {
           />
         </View>
 
-        <Pressable onPress={onPressSave}>
+        <Pressable onPress={onPressSave} disabled={isPending}>
           <MainGradient style={styles.flightSaveButton}>
             <Text style={styles.flightSaveButtonText}>비행기록 저장하기</Text>
           </MainGradient>

--- a/components/(tabs)/schedule/ButtonSection.tsx
+++ b/components/(tabs)/schedule/ButtonSection.tsx
@@ -8,22 +8,25 @@ import { useScheduleStore } from "@/store/useScheduleStore";
 import { useRouter } from "expo-router";
 import React from "react";
 import { StyleSheet, View } from "react-native";
+import { useShallow } from "zustand/react/shallow";
 
 export default function ButtonSection() {
   const { queryClient, ...mutation } = useAddSchedule();
 
-  const currentStep = useScheduleStore((state) => state.currentStep);
+  const { currentStep, currentMarkedDates, dayData } = useScheduleStore(
+    useShallow((state) => ({
+      currentStep: state.currentStep,
+      currentMarkedDates: state.currentMarkedDates,
+      dayData: state.dayData,
+    }))
+  );
   const nextEnabled = useScheduleStore(validateNextStepEnabled);
   const goToPrevStep = useScheduleStore((state) => state.goToPrevStep);
   const goToNextStep = useScheduleStore((state) => state.goToNextStep);
-  const currentMarkedDates = useScheduleStore(
-    (state) => state.currentMarkedDates
-  );
   const setCurrentMarkedDates = useScheduleStore(
     (state) => state.setCurrentMarkedDates
   );
   const resetAllStates = useScheduleStore((state) => state.resetAllStates);
-  const dayData = useScheduleStore((state) => state.dayData);
   const currentStepKey = Screens[currentStep].key;
   const isAddingSchedule = currentStepKey === "EditPlan";
   const isComplete = currentStepKey === "Complete";
@@ -44,6 +47,7 @@ export default function ButtonSection() {
   };
 
   const addSchedule = async () => {
+    if (mutation.isPending) return;
     const confirmed = await useModalStore.getState().showConfirm({
       title: "일정 추가",
       description: "수정한 일정을 추가하시겠습니까?",
@@ -115,9 +119,9 @@ export default function ButtonSection() {
     <CustomButton
       text={isAddingSchedule ? "일정 추가하기" : "다음 단계"}
       onPress={isAddingSchedule ? addSchedule : handleNextButtonPress}
-      containerStyle={{ flex: 1 }}
+      containerStyle={styles.rightButtonContainer}
       textStyle={styles.rightButtonText}
-      disabled={!nextEnabled}
+      disabled={!nextEnabled || (isAddingSchedule && mutation.isPending)}
     />
   );
 
@@ -125,7 +129,7 @@ export default function ButtonSection() {
     <View
       style={[
         styles.container,
-        currentStepKey.includes("Loading") && { display: "none" },
+        currentStepKey.includes("Loading") && styles.hidden,
       ]}
     >
       {isComplete ? (
@@ -136,7 +140,7 @@ export default function ButtonSection() {
             router.push("/");
             queryClient.invalidateQueries({ queryKey: ["mySchedule"] });
           }}
-          containerStyle={{ flex: 1, maxWidth: 354 }}
+          containerStyle={styles.completeButtonContainer}
         />
       ) : (
         <>
@@ -176,5 +180,15 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 500,
     lineHeight: 20,
+  },
+  rightButtonContainer: {
+    flex: 1,
+  },
+  completeButtonContainer: {
+    flex: 1,
+    maxWidth: 354,
+  },
+  hidden: {
+    display: "none",
   },
 });


### PR DESCRIPTION
## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정

## ✨ 추가/수정 내용

### 문제
`ButtonSection`의 "일정 추가하기" 버튼과 `report.tsx`의 "비행기록 저장하기" 버튼 모두 API 요청 진행 중에도 중복으로 눌릴 수 있어, 동일한 API가 중복 호출될 수 있었습니다.

### 해결

**① `components/(tabs)/schedule/ButtonSection.tsx`**
- `addSchedule` 함수 진입 시 `mutation.isPending` 체크 추가
- RightButton의 `disabled` 조건에 `isAddingSchedule && mutation.isPending` 추가

**② `app/(tabs)/air/report.tsx`**
- `usePostFlightLog`에서 `isPending` 구조분해 추가
- `onPressSave` 함수 진입 시 `isPending` 체크 추가
- `Pressable`에 `disabled={isPending}` 추가

## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

Closes #78